### PR TITLE
Add add_decendecy 'rubocop', ">= 0.35.0" 

### DIFF
--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'rubocop', ">= 0.35.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Why don't you add add_decendecy 'rubocop', ">= 0.35.0" ?
Because onkcop depends on 'inherit_gem' operator that added since ['0.35.0'](https://github.com/bbatsov/rubocop/releases/tag/v0.35.0).
