### PR TITLE
Write recommendation Gemfile format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ bundle exec rubocop <options...>
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "onkcop"
+group :development do
+  gem "onkcop", require: nil
+end
 ```
 
 ## Contributing


### PR DESCRIPTION
- onkcop should be used on development environment.
  (onkcop is needless on production environment.)
- App should not `require` onkcop.
