### PR TITLE
Bump rubocop-rspec v1.9.1

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -20,14 +20,6 @@ RSpec/ImplicitExpect:
 RSpec/InstanceVariable:
   Enabled: false
 
-# mock ではなく spy を使うのを推奨したい。
-# ただメッセージが悪く、「mock ではなく stub を使え」と言っているように読み取れる
-# (そのため Enabled: false になった) ので
-# https://github.com/backus/rubocop-rspec/pull/224
-# が cop 名も分かりやすくなって良さそう。
-RSpec/MessageExpectation:
-  Enabled: true
-
 # 強く 1 example 1 assertion の立場は取らないが、多すぎてもツラいので。
 # aggregate_failures で囲われていたら無視する的なオプション欲しい。
 RSpec/MultipleExpectations:

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.46.0"
-  spec.add_dependency "rubocop-rspec", ">= 1.8.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.9.1"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Disable `RSpec/MessageExpectation` cop that is replaced with a new cop: `RSpec/MessageSpies`.