### PR TITLE
Disable Style/ZeroLengthPredicate cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -214,6 +214,15 @@ Style/TernaryParentheses:
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
+# 条件式で arr.size > 0 が使われた時に
+#   if !arr.empty?
+#   else
+#   end
+# に修正されるのが嫌。
+# 中身を入れ替えて否定外しても良いんだけど、どちらが例外的な処理なのかが分かりづらくなる。
+Style/ZeroLengthPredicate:
+  Enabled: false
+
 ##################### Lint ##################################
 
 # RuntimeError は「特定の Error を定義できない場合」なので、


### PR DESCRIPTION
if `size > 0` is used in condition, code will be auto-corrected like this.

```ruby
if !arr.empty?
  a
else
  b
end
```

`if !cond - else` is not readable.

it is one way to remove `!` and swap a & b,
but readability depends on which process is the main focus.