### PR TITLE
Update rubocop v0.47.1

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -244,12 +244,13 @@ Metrics/AbcSize:
   Max: 24
 
 # Gemfile, Guardfile は DSL 的で基本的に複雑にはならないので除外
-# routes は巨大な block 不可避なので除外
+# rake, rspec, routes は巨大な block 不可避なので除外
+# TODO: ExcludedMethods の精査
 Metrics/BlockLength:
   Exclude:
-    - "Rakefile"     # default
-    - "**/*.rake"    # default
-    - "spec/**/*.rb" # default
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
     - "Gemfile"
     - "Guardfile"
     - "config/routes.rb"

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -277,3 +277,9 @@ Metrics/MethodLength:
 # 分岐の数。ガード句を多用しているとデフォルト 7 だと厳しい
 Metrics/PerceivedComplexity:
   Max: 8
+
+##################### Security ##################################
+
+# 毎回 YAML.safe_load(yaml_str, [Date, Time]) するのは面倒で。。
+Security/YAMLLoad:
+  Enabled: false

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -191,10 +191,6 @@ Style/Semicolon:
   Exclude:
     - "spec/**/*"
 
-# いくらなんでも inject { |a, e| } は短すぎるので分かりやすい名前をつけたい
-Style/SingleLineBlockParams:
-  Enabled: false
-
 # * 式展開したい場合に書き換えるのが面倒
 # * 文章ではダブルクォートよりもシングルクォートの方が頻出する
 # ことから EnforcedStyle: double_quotes 推奨

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.46.0"
+  spec.add_dependency "rubocop", "~> 0.47.1"
   spec.add_dependency "rubocop-rspec", ">= 1.9.1"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.47.1"
-  spec.add_dependency "rubocop-rspec", ">= 1.9.1"
+  spec.add_dependency "rubocop-rspec", ">= 1.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
* Update to `rubocop` v0.47.1 and `rubocop-rspec` v1.10.0.
* Remove `Style/SingleLineBlockParams` cop config because disabled by default.
* Disable new `Security/YAMLLoad` cop.

worried points:

*   `Security/YAMLLoad`
    *   I think `Enabled: false`, but this is `Security` department cop.
*   `Security/MarshalLoad`
    *   There is well known technique to deep copy object.
        ```ruby
        Marshal.load(Marshal.dump(obj))
        ```
    *   It is not heavily used, so easy to add disable comment.
*   `Metrics/BlockLength`
    *   Default configuration changed from exclude per-files to exclude per-methods.
    *   Exclude per-files excludes too much. I have to scrutinize exclude methods.
*   `Rails/SkipsModelValidations`
    *   Sometimes dare to use `update_all`, `increment`. (10..20 times per application)
    *   This cop means
         "When using a method that skips validations, always write `rubocop:disable` comment.".
        It's OK?
