### PR TITLE
Update rubocop-rspec dependency version to >= 1.11.0

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -2,7 +2,7 @@ require: "rubocop-rspec"
 
 # subject はコピペ可搬性よりもそのまま USAGE であって欲しい
 RSpec/DescribedClass:
-  Enabled: false
+  EnforcedStyle: explicit
 
 # each で回したり aggregate_failures 使ってたりすると厳しい。
 # feature spec は exclude でも良いかもしれない。

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.47.1"
-  spec.add_dependency "rubocop-rspec", ">= 1.10.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.11.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
* `RSpec/DescribedClass` cop now has SupportedStyles. Use `EnforcedStyle: explicit`
* Other updates feel good
