### PR TITLE
Allow to exclude gemspec file from Metrics/BlockLength

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -255,6 +255,7 @@ Metrics/BlockLength:
     - "Guardfile"
     - "config/routes.rb"
     - "config/routes/**/*.rb"
+    - "*.gemspec"
 
 # 6 は強すぎるので緩める
 Metrics/CyclomaticComplexity:


### PR DESCRIPTION
It seems to be deprecated to exclude by `Exclude`, but
this can not be exclude by `ExcludedMethods`.
(`new` is very very frequent method)

```ruby
Gem::Specification.new do |spec|
  ...
end
```