### PR TITLE
Update rubocop-rspec dependency version to >= 1.12.0

### DIFF
--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.47.1"
-  spec.add_dependency "rubocop-rspec", ">= 1.11.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.12.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
new cops:

* RSpec/InstanceSpy
  * ok
* RSpec/BeforeAfterAll
  * This cop excludes `spec_helper`, `spec/support/**/*`. It's okey.