### PR TITLE
Update rubocop-rspec dependency version to >= 1.15.0

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -21,7 +21,6 @@ RSpec/InstanceVariable:
   Enabled: false
 
 # 強く 1 example 1 assertion の立場は取らないが、多すぎてもツラいので。
-# aggregate_failures で囲われていたら無視する的なオプション欲しい。
 RSpec/MultipleExpectations:
   Max: 3
 

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.47.1"
-  spec.add_dependency "rubocop-rspec", ">= 1.12.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.15.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
* New cops since rubocop-rspec v1.13.0 are all reasonable
* `Rspec/MultipleExpectations` cop now count `aggregate_failures` block as single expectation