### PR TITLE
Update rubocop v0.48.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.4
+  # uncomment if use rails cops
+  # TargetRailsVersion: 5.0
 ```
 
 ```sh

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,6 +1,10 @@
 Rails:
   Enabled: true
 
+# v0.48.0 に `||` でエラーになるバグがあるため。 pull/4175
+Rails/Blank:
+  Enabled: false
+
 # slug とか created_by とか、NOT NULL だが create_table 時に
 # default 値を定義できないカラムは存在する。
 Rails/NotNullColumn:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -150,9 +150,10 @@ Style/MethodCalledOnDoEndBlock:
 # 1_000_000 と区切り文字が 2 個以上必要になる場合のみ _ 区切りを必須にする
 # 10_000_00 は許可しない。(これは例えば 10000 ドルをセント単位にする時に便利だが
 # 頻出しないので foolproof に振る
+# TODO: Strict パラメータは warning が出るので一旦無効に。 pull/4180
 Style/NumericLiterals:
   MinDigits: 7
-  Strict: true
+  # Strict: true
 
 # foo.positive? は foo > 0 に比べて意味が曖昧になる
 # foo.zero? は許可したいけどメソッドごとに指定できないので一括で disable に

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -148,6 +148,12 @@ Style/Lambda:
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
+# RSpec の matcher を誤検知するため
+#   expect(array).to include("a", "b")
+Style/MixinGrouping:
+  Exclude:
+    - "spec/**/*"
+
 # メソッドチェーン感がより感じられるインデントにする
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - "db/schema.rb"
   DisplayCopNames: true
 
-##################### Style ##################################
+#################### Style #################################
 
 # レキシカルスコープの扱いが alias_method の方が自然。
 # https://ernie.io/2014/10/23/in-defense-of-alias/ のように
@@ -224,7 +224,7 @@ Style/TrailingCommaInLiteral:
 Style/ZeroLengthPredicate:
   Enabled: false
 
-##################### Lint ##################################
+#################### Lint ##################################
 
 # Style/EmptyCaseCondition と同じく網羅の表現力が empty when を認めた方が高いし、
 # 頻出する対象を最初の when で撥ねるのはパフォーマンス向上で頻出する。
@@ -255,7 +255,7 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnusedMethodArgument:
   Enabled: false
 
-##################### Metrics ##################################
+#################### Metrics ###############################
 
 # 30 まではギリギリ許せる範囲だったけど
 # リリースごとに 3 ずつぐらい下げていきます。20 まで下げたい。
@@ -298,7 +298,7 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 8
 
-##################### Security ##################################
+#################### Security ##############################
 
 # 毎回 YAML.safe_load(yaml_str, [Date, Time]) するのは面倒で。。
 Security/YAMLLoad:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -221,6 +221,11 @@ Style/StringLiteralsInInterpolation:
 Style/StringMethods:
   Enabled: true
 
+# %w() と %i() が見分けづらいので Style/WordArray と合わせて無効に。
+# 書き手に委ねるという意味で、Enabled: false にしています。使っても良い。
+Style/SymbolArray:
+  Enabled: false
+
 # 三項演算子は分かりやすく使いたい。
 # () を外さない方が条件式が何なのか読み取りやすいと感じる。
 Style/TernaryParentheses:
@@ -229,6 +234,11 @@ Style/TernaryParentheses:
 # 複数行の場合はケツカンマを入れる
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+
+# %w() と %i() が見分けづらいので Style/SymbolArray と合わせて無効に。
+# 書き手に委ねるという意味で、Enabled: false にしています。使っても良い。
+Style/WordArray:
+  Enabled: false
 
 # 条件式で arr.size > 0 が使われた時に
 #   if !arr.empty?

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -148,8 +148,11 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
 # 1_000_000 と区切り文字が 2 個以上必要になる場合のみ _ 区切りを必須にする
+# 10_000_00 は許可しない。(これは例えば 10000 ドルをセント単位にする時に便利だが
+# 頻出しないので foolproof に振る
 Style/NumericLiterals:
   MinDigits: 7
+  Strict: true
 
 # foo.positive? は foo > 0 に比べて意味が曖昧になる
 # foo.zero? は許可したいけどメソッドごとに指定できないので一括で disable に

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,6 +1,3 @@
-# target_version:
-#   rubocop v0.47.1
-
 # 自動生成されるものはチェック対象から除外する
 AllCops:
   Exclude:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - "vendor/**/*" # rubocop config/default.yml
     - "db/schema.rb"
+    - "node_modules/**/*"
   DisplayCopNames: true
 
 #################### Style #################################

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -147,6 +147,10 @@ Style/Lambda:
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
+# メソッドチェーン感がより感じられるインデントにする
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
 # 1_000_000 と区切り文字が 2 個以上必要になる場合のみ _ 区切りを必須にする
 # 10_000_00 は許可しない。(これは例えば 10000 ドルをセント単位にする時に便利だが
 # 頻出しないので foolproof に振る

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -235,6 +235,17 @@ Style/ZeroLengthPredicate:
 
 #################### Lint ##################################
 
+# メソッドの引数に lambda を渡すパターンが検出されるため。
+# この場合は単一引数だし Ambiguous ではない (と思う) ので誤検知っぽい。
+#   some_method ->(a) { a }
+# pull/4191 で修正済み
+#
+# assignment(`=`) が OK で `==`, `!=` が NG なのも考慮漏れっぽく見える。
+#   if [a, b] != array.sort_by { |e| e["id"] }
+# は右から評価されるのを意図しているし違和感無い。
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 # Style/EmptyCaseCondition と同じく網羅の表現力が empty when を認めた方が高いし、
 # 頻出する対象を最初の when で撥ねるのはパフォーマンス向上で頻出する。
 # また、

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.47.1"
+  spec.add_dependency "rubocop", "~> 0.48.0"
   spec.add_dependency "rubocop-rspec", ">= 1.15.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -8,3 +8,5 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.4
+  # uncomment if use rails cops
+  # TargetRailsVersion: 5.0


### PR DESCRIPTION
* Update `rubocop` v0.48.0.
* Disable new `Lint/AmbiguousBlockAssociation` cop.
* Disable new `Rails/Blank` cop.
* Disable `Style/SymbolArray`, `StyleWordArray` cop.
* Change `Style/MultilineMethodCallIndentation` to `indented_relative_to_receiver` style.
* Exclude RSpec directory from new `Style/MixinGrouping` cop.
* Ignore `node_modules` dir.
* Add `TargetRailsVersion` to README and template