### PR TITLE
Enable Style/TrailingCommaInArguments: { EnforcedStyleForMultiline: comma }

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -225,10 +225,20 @@ Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 
 # 複数行の場合はケツカンマを入れる(引数)
+# Ruby は関数の引数もカンマを許容しているので
+# * 単行は常にケツカンマ無し
+# * 複数行は常にケツカンマ有り
+# に統一したい。
+# 見た目がアレだが、ES2017 でも関数引数のケツカンマが許容されるので
+# 世界はそちらに向かっている。
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
 # 複数行の場合はケツカンマを入れる(リテラル)
+# JSON がケツカンマを許していないという反対意見もあるが、
+# 古い JScript の仕様に縛られる必要は無い。
+# IE9 以降はリテラルでケツカンマ OK なので正しい差分行の検出に寄せる。
+# 2 insertions(+), 1 deletion(-) ではなく、1 insertions
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -224,8 +224,12 @@ Style/SymbolArray:
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 
-# 複数行の場合はケツカンマを入れる
+# 複数行の場合はケツカンマを入れる(リテラル)
 Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+# 複数行の場合はケツカンマを入れる(引数)
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
 # 0 <= foo && foo < 5 のように数直線上に並べるのは

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -224,12 +224,12 @@ Style/SymbolArray:
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 
-# 複数行の場合はケツカンマを入れる(リテラル)
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma
-
 # 複数行の場合はケツカンマを入れる(引数)
 Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+# 複数行の場合はケツカンマを入れる(リテラル)
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
 # 0 <= foo && foo < 5 のように数直線上に並べるのは


### PR DESCRIPTION
```
# Good
foo(
  1,
  2,
)
```

- Rubyはリテラル、引数ともにケツカンマを許しています
- 複数行ケツカンマはgit等の差分を綺麗にします（実態はadd:1なのにadd:2/delete:1になるのを防ぐ）
- リテラルがケツカンマ推奨なので引数もケツカンマ推奨にするほうが一貫性があります
- 世界はケツカンマを許すほうへ動いています（JavaScriptは昔リテラル引数ともケツカンマを許さなかった(IEなど)が、現在はリテラルで許すようになり、さらにES2017では引数でも許す提案がなされているなど）

ゆえに引数もケツカンマ推奨にしたいと思います。
