### PR TITLE
Disable Performance/Casecmp cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -344,6 +344,13 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 8
 
+#################### Performance ###########################
+
+# downcase or upcase しての比較はイディオムの域なので、多少の
+# パフォーマンスの違いがあろうが casecmp に変える意義を感じない
+Performance/Casecmp:
+  Enabled: false
+
 #################### Security ##############################
 
 # 毎回 YAML.safe_load(yaml_str, [Date, Time]) するのは面倒で。。


### PR DESCRIPTION
Comparison with downcase or upcase is an idiom.
Idioms have higher priority than some performance improvement.

1.2x faster is not critical.

```ruby
require "benchmark/ips"
Benchmark.ips do |x|
  a = "foo"
  b = "Foo"
  x.report("downcase") { a.downcase == b }
  x.report("casecmp")  { a.casecmp(b) }
  x.compare!
end
```

```
Warming up --------------------------------------
            downcase   179.127k i/100ms
             casecmp   203.340k i/100ms
Calculating -------------------------------------
            downcase      5.126M (±12.2%) i/s -     25.257M in   5.013800s
             casecmp      6.188M (±17.0%) i/s -     29.891M in   5.010809s

Comparison:
             casecmp:  6187759.2 i/s
            downcase:  5125593.1 i/s - same-ish: difference falls within error
```