### PR TITLE
Update rubocop dependency version to 0.50.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -365,6 +365,11 @@ Metrics/PerceivedComplexity:
 Performance/Casecmp:
   Enabled: false
 
+# 2.4 以降では each_key でも特にパフォーマンスに差が無いので
+# 読みやすさはほとんど変わらないし、書きやすさを取る。
+Performance/HashEachMethods:
+  Enabled: false
+
 #################### Security ##############################
 
 # 毎回 YAML.safe_load(yaml_str, [Date, Time]) するのは面倒で。。

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,9 +1,9 @@
 # 自動生成されるものはチェック対象から除外する
 AllCops:
   Exclude:
-    - "vendor/**/*" # rubocop config/default.yml
+    - "node_modules/**/*" # rubocop config/default.yml
+    - "vendor/**/*"       # rubocop config/default.yml
     - "db/schema.rb"
-    - "node_modules/**/*"
   DisplayCopNames: true
 
 #################### Layout ################################

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -164,6 +164,11 @@ Style/NumericLiterals:
 Style/NumericPredicate:
   Enabled: false
 
+# falsy な場合という条件式の方を意識させたい場合がある。
+# Style/IfUnlessModifier と同じ雰囲気。
+Style/OrAssignment:
+  Enabled: false
+
 # 正規表現にマッチさせた時の特殊変数の置き換えは Regex.last_match ではなく
 # 名前付きキャプチャを使って参照したいので auto-correct しない
 Style/PerlBackrefs:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -290,6 +290,13 @@ Lint/EmptyWhen:
 Lint/InheritException:
   EnforcedStyle: standard_error
 
+# 無指定だと StandardError を rescue するのは常識の範疇なので。
+# https://github.com/bbatsov/rubocop/issues/2943#issuecomment-330498533
+# rescue 後に何をするかは Lint/HandleExceptions でチェックするので
+# ココで想起させる必要は無さそう。
+Lint/RescueWithoutErrorClass:
+  Enabled: false
+
 # * 同名のメソッドがある場合にローカル変数に `_` を付ける
 # * 一時変数として `_` を付ける
 # というテクニックは頻出する

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -169,15 +169,6 @@ Style/NumericPredicate:
 Style/PerlBackrefs:
   AutoCorrect: false
 
-# has_ から始まるメソッドは許可する
-Style/PredicateName:
-  NamePrefixBlacklist:
-    - "is_"
-    - "have_"
-  NamePrefix:
-    - "is_"
-    - "have_"
-
 # Hash#has_key? の方が key? よりも意味が通る
 Style/PreferredHashMethods:
   EnforcedStyle: verbose
@@ -260,6 +251,17 @@ Style/WordArray:
 # 中身を入れ替えて否定外しても良いんだけど、どちらが例外的な処理なのかが分かりづらくなる。
 Style/ZeroLengthPredicate:
   Enabled: false
+
+#################### Naming ################################
+
+# has_ から始まるメソッドは許可する
+Naming/PredicateName:
+  NamePrefixBlacklist:
+    - "is_"
+    - "have_"
+  NamePrefix:
+    - "is_"
+    - "have_"
 
 #################### Lint ##################################
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -243,10 +243,9 @@ Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
 # 0 <= foo && foo < 5 のように数直線上に並べるのは
-# コードを読みやすくするテクニック。
-# また、self == other, __FILE__ == $0 はイディオムなので許可。
+# コードを読みやすくするテクニックなので equality_operators_only に。
 Style/YodaCondition:
-  Enabled: false
+  EnforcedStyle: equality_operators_only
 
 # %w() と %i() が見分けづらいので Style/SymbolArray と合わせて無効に。
 # 書き手に委ねるという意味で、Enabled: false にしています。使っても良い。

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.49.1"
-  spec.add_dependency "rubocop-rspec", ">= 1.16.0"
+  spec.add_dependency "rubocop", "~> 0.50.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.18.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
* Update `rubocop` v0.50.0 and `rubocop-rspec` v1.18.0
* Disable `Performance/HashEachMethods` cop
* Disable new `Style/OrAssignment` cop
* Change cop's department from `Style` to `Naming`
* Disable new `Lint/RescueWithoutErrorClass` cop
* `node_modules` directory is now excluded by rubocop as default
* Enable `Style/YodaCondition` cop with `equality_operators_only` style
