### PR TITLE
Update rubocop-rspec to v1.20.0

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,5 +1,9 @@
 require: "rubocop-rspec"
 
+# 日本語だと「〜の場合」になるので suffix でないと対応できない
+RSpec/ContextWording:
+  Enabled: false
+
 # subject はコピペ可搬性よりもそのまま USAGE であって欲しい
 RSpec/DescribedClass:
   EnforcedStyle: explicit

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.51.0"
-  spec.add_dependency "rubocop-rspec", ">= 1.19.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.20.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
RSpec/ContextWording
: In Japanese, words expressing context are suffixes.
