### PR TITLE
Exclude only RSpec examples

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -53,7 +53,7 @@ Layout/MultilineMethodCallIndentation:
 # { foo } は明らかに change に紐付く。
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - "spec/**/*"
+    - "spec/**/*_spec.rb"
 
 # Style/EmptyCaseCondition と同じく網羅の表現力が empty when を認めた方が高いし、
 # 頻出する対象を最初の when で撥ねるのはパフォーマンス向上で頻出する。
@@ -102,7 +102,7 @@ Metrics/BlockLength:
   Exclude:
     - "Rakefile"
     - "**/*.rake"
-    - "spec/**/*.rb"
+    - "spec/**/*_spec.rb"
     - "Gemfile"
     - "Guardfile"
     - "config/environments/*.rb"
@@ -187,7 +187,7 @@ Style/AsciiComments:
 Style/BlockDelimiters:
   AutoCorrect: false
   Exclude:
-    - "spec/**/*"
+    - "spec/**/*_spec.rb"
 
 # option 等、明示的にハッシュにした方が分かりやすい場合もある
 Style/BracesAroundHashParameters:
@@ -347,7 +347,7 @@ Style/SafeNavigation:
 # spec 内は見た目が綺麗になるので許可
 Style/Semicolon:
   Exclude:
-    - "spec/**/*"
+    - "spec/**/*_spec.rb"
 
 # * 式展開したい場合に書き換えるのが面倒
 # * 文章ではダブルクォートよりもシングルクォートの方が頻出する


### PR DESCRIPTION
Should include spec/support/*, spec/*_helper.rb, etc.