### PR TITLE
Update rubocop v0.52.0 and rubocop-rspec v1.21.0

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -32,9 +32,14 @@ RSpec/ImplicitExpect:
 RSpec/InstanceVariable:
   Enabled: false
 
-# 強く 1 example 1 assertion の立場は取らないが、多すぎてもツラいので。
+# spec_helper で meta[:aggregate_failures] を設定することで
+# aggregate_failures が全ての spec で有効になる。
+#
+# ほぼ MultipleExpectations についてはチェックされなくなる設定なので注意。
+# パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
+# 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  Max: 3
+  AggregateFailuresByDefault: true
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -7,6 +7,14 @@ AllCops:
 
 #################### Layout ################################
 
+# メソッドをグループ分けして書き順を揃えておくと読みやすくなる。
+# 多少のツラミはあるかもしれない。
+# TODO: Categories を調整することで
+# https://github.com/pocke/rubocop-rails-order_model_declarative_methods
+# を再現できそう。
+Layout/ClassStructure:
+  Enabled: true
+
 # メソッドチェーンの改行は末尾に . を入れる
 # REPL に貼り付けた際の暴発を防ぐため
 Layout/DotPosition:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -245,6 +245,12 @@ Style/EmptyMethod:
 Style/FormatString:
   EnforcedStyle: percent
 
+# strftime("%Y%m%d") の %d で引っかかる false positive がある。
+# また、url escape でも引っかかるらしい。
+# see: pull/5230, issues/5242
+Style/FormatStringToken:
+  Enabled: false
+
 # まだ対応するには早い
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -66,13 +66,6 @@ Lint/EmptyWhen:
 Lint/InheritException:
   EnforcedStyle: standard_error
 
-# 無指定だと StandardError を rescue するのは常識の範疇なので。
-# https://github.com/bbatsov/rubocop/issues/2943#issuecomment-330498533
-# rescue 後に何をするかは Lint/HandleExceptions でチェックするので
-# ココで想起させる必要は無さそう。
-Lint/RescueWithoutErrorClass:
-  Enabled: false
-
 # * 同名のメソッドがある場合にローカル変数に `_` を付ける
 # * 一時変数として `_` を付ける
 # というテクニックは頻出する
@@ -311,6 +304,10 @@ Style/RedundantReturn:
 # 特に model 内において、ローカル変数とメソッド呼び出しの区別をつけた方が分かりやすい場合が多い
 Style/RedundantSelf:
   Enabled: false
+
+# 無指定だと StandardError を rescue するのは常識の範疇なので。
+Style/RescueStandardError:
+  EnforcedStyle: implicit
 
 # user&.admin? が、[nil, true, false] の 3 値を返すことに一瞬で気づけず
 # boolean を返すっぽく見えてしまうので無効に。

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -4,7 +4,6 @@ AllCops:
     - "node_modules/**/*" # rubocop config/default.yml
     - "vendor/**/*"       # rubocop config/default.yml
     - "db/schema.rb"
-  DisplayCopNames: true
 
 #################### Layout ################################
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -271,6 +271,15 @@ Style/Lambda:
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
+# この 2 つは単発で動かすのが分かっているので Object を汚染しても問題ない。
+# spec/dummy は Rails Engine を開発するときに絶対に引っかかるので入れておく。
+Style/MixinUsage:
+  Exclude:
+    - "bin/setup"
+    - "bin/update"
+    - "spec/dummy/bin/setup"
+    - "spec/dummy/bin/update"
+
 # 1_000_000 と区切り文字が 2 個以上必要になる場合のみ _ 区切りを必須にする
 # 10_000_00 は許可しない。(これは例えば 10000 ドルをセント単位にする時に便利だが
 # 頻出しないので foolproof に振る

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -44,6 +44,10 @@ Layout/IndentationConsistency:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 
+# デフォルト値がおかしい。
+# v0.52.1 で解消。 see: pull/5263
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyleForEmptyBraces: space
 
 #################### Lint ##################################
 

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.51.0"
-  spec.add_dependency "rubocop-rspec", ">= 1.20.0"
+  spec.add_dependency "rubocop", "~> 0.52.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.21.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
* Update `rubocop` v0.52.0 and `rubocop-rspec` v1.21.0
* Remove `DisplayCopNames` configuration
* Enable new `Style/ClassStructure` cop
* Disalbe `Style/FormatStringToken` cop
* Change `Layout/SpaceBeforeBlockBraces` cop's empty braces style to `space`
* Change `Style/RescueStandardError` cop to implicit style
* Change `RSpec/MultipleExpectations` cop to `AggregateFailuresByDefault` style
* Exclude `bin/setup`, `bin/update` from `Style/MixinUsage` cop
