### PR TITLE
Bump rubocop to v0.52.1

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -248,6 +248,7 @@ Style/FormatString:
 # strftime("%Y%m%d") の %d で引っかかる false positive がある。
 # また、url escape でも引っかかるらしい。
 # see: pull/5230, issues/5242
+# 上記 PR はマージされたが、まだダメっぽいので引き続き disable にする
 Style/FormatStringToken:
   Enabled: false
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -44,10 +44,6 @@ Layout/IndentationConsistency:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 
-# デフォルト値がおかしい。
-# v0.52.1 で解消。 see: pull/5263
-Layout/SpaceBeforeBlockBraces:
-  EnforcedStyleForEmptyBraces: space
 
 #################### Lint ##################################
 

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.52.0"
+  spec.add_dependency "rubocop", "~> 0.52.1"
   spec.add_dependency "rubocop-rspec", ">= 1.21.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
* Update `rubocop` to v0.52.1
* Use Layout/SpaceBeforeBlockBraces cop's default configuration
