### PR TITLE
Exclude all spec directories again on `Metrics/BlockLength` cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -102,7 +102,7 @@ Metrics/BlockLength:
   Exclude:
     - "Rakefile"
     - "**/*.rake"
-    - "spec/**/*_spec.rb"
+    - "spec/**/*.rb"
     - "Gemfile"
     - "Guardfile"
     - "config/environments/*.rb"


### PR DESCRIPTION
Several files are detected such as spec_helper, factories and
shared_examples.

```
spec/rails_helper.rb:58:1: C: : Block has too many lines. [46/25]
RSpec.configure do |config| ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```
spec/factories/users.rb:1:1: C: Metrics/BlockLength: Block has too many lines. [28/25]
FactoryBot.define do ...
^^^^^^^^^^^^^^^^^^^^
```