### PR TITLE
Update rubocop v0.53.0 and rubocop-rspec v1.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.5
-  # uncomment if use rails cops
-  # TargetRailsVersion: 5.1
 ```
 
 ```sh

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -158,11 +158,6 @@ Naming/PredicateName:
 Performance/Casecmp:
   Enabled: false
 
-# 2.4 以降では each_key でも特にパフォーマンスに差が無いので
-# 読みやすさはほとんど変わらないし、書きやすさを取る。
-Performance/HashEachMethods:
-  Enabled: false
-
 
 #################### Security ##############################
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -93,6 +93,12 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnusedMethodArgument:
   Enabled: false
 
+# select 以外では引っかからないと思うので
+# mutating_methods のチェックを有効に。
+# TODO: select は引数が無い (ブロックのみ) の場合にだけチェックする
+# ようにすると誤検知がほぼ無くなる？
+Lint/Void:
+  CheckForMethodsWithNoSideEffects: true
 
 #################### Metrics ###############################
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -150,6 +150,12 @@ Naming/PredicateName:
     - "is_"
     - "have_"
 
+# 3 文字未満だと指摘されるが、未使用を示す _ や e(rror), b(lock),
+# n(umber) といった 1 文字変数は頻出するし、前置詞(by, to, ...)や
+# よく知られた省略語 (op: operator とか pk: primary key とか) も妥当。
+# 変数 s にどんな文字列かを形容したい場合と、不要な場合とがある＝無効
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
 
 #################### Performance ###########################
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -252,13 +252,6 @@ Style/EmptyMethod:
 Style/FormatString:
   EnforcedStyle: percent
 
-# strftime("%Y%m%d") の %d で引っかかる false positive がある。
-# また、url escape でも引っかかるらしい。
-# see: pull/5230, issues/5242
-# 上記 PR はマージされたが、まだダメっぽいので引き続き disable にする
-Style/FormatStringToken:
-  Enabled: false
-
 # まだ対応するには早い
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -249,6 +249,10 @@ Style/EmptyCaseCondition:
 Style/EmptyElse:
   EnforcedStyle: empty
 
+# ガード句と本質を分けるのは良いコードスタイルなので有効化
+Style/EmptyLineAfterGuardClause:
+  Enabled: true
+
 # 空メソッドの場合だけ1行で書かなければいけない理由が無い
 # 「セミコロンは使わない」に寄せた方がルールがシンプル
 Style/EmptyMethod:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -390,12 +390,16 @@ Style/TernaryParentheses:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-# 複数行の場合はケツカンマを入れる(リテラル)
+# 複数行の場合はケツカンマを入れる(Arrayリテラル)
 # JSON がケツカンマを許していないという反対意見もあるが、
 # 古い JScript の仕様に縛られる必要は無い。
 # IE9 以降はリテラルでケツカンマ OK なので正しい差分行の検出に寄せる。
 # 2 insertions(+), 1 deletion(-) ではなく、1 insertions
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+# 複数行の場合はケツカンマを入れる(Hashリテラル)
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 # %w() と %i() が見分けづらいので Style/SymbolArray と合わせて無効に。

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.52.1"
-  spec.add_dependency "rubocop-rspec", ">= 1.22.0"
+  spec.add_dependency "rubocop", "~> 0.53.0"
+  spec.add_dependency "rubocop-rspec", ">= 1.24.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -8,5 +8,3 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.5
-  # uncomment if use rails cops
-  # TargetRailsVersion: 5.1


### PR DESCRIPTION
* Update `rubocop` v0.53.0 and `rubocop-rspec` v1.24.0
* `Style/TrailingCommaInLiteral` cop is separated to `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral`
* `Performance/HashEachMethods` cop is removed
* Disable new `Naming/UncommunicativeMethodParamName` cop
* Enable `Style/FormatStringToken` cop
* Enable new `Style/EmptyLineAfterGuardClause` cop
* Enable `Lint/Void` cop's mutating methods check
* Remove `TargetRailsVersion` from template
