### PR TITLE
Relax rubocop dependency for rubocop-rspec

### DIFF
--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.53.0"
+  spec.add_dependency "rubocop", ">= 0.53.0"
   spec.add_dependency "rubocop-rspec", ">= 1.24.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
factory_bot v4.11.0 deprecates static attributes.

* https://github.com/thoughtbot/factory_bot/blob/v4.11.0/NEWS#L1-L4
* https://github.com/thoughtbot/factory_bot/pull/1166
* https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#static-attributes

rubocop-rspec v1.28.0+ add `RSpec/FactoryBot/AttributeDefinedStatically` for this issue.

* https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md#1280-2018-08-14
* https://github.com/rubocop-hq/rubocop-rspec/blob/v1.28.0/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb

I want to convert from static attributes to dynamic attributes in my factorties
with `rubocop --auto-correct`, but onkcop locks rubocop version :cry:

```
Bundler could not find compatible versions for gem "rubocop":
  In Gemfile:
    onkcop was resolved to 0.53.0.0, which depends on
      rubocop (~> 0.53.0)

    rubocop-rspec (>= 1.28.0) was resolved to 1.28.0, which depends on
      rubocop (>= 0.58.0)
```

So I want to relax dependency.