### PR TITLE
Move Style/EmptyLineAfterGuardClause cop to Layout department

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -21,6 +21,10 @@ Layout/ClassStructure:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+# ガード句と本質を分けるのは良いコードスタイルなので有効化
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
+
 # 桁揃えが綺麗にならないことが多いので migration は除外
 Layout/ExtraSpacing:
   Exclude:
@@ -248,10 +252,6 @@ Style/EmptyCaseCondition:
 # 明示的に else で nil を返すのは分かりやすいので許可する
 Style/EmptyElse:
   EnforcedStyle: empty
-
-# ガード句と本質を分けるのは良いコードスタイルなので有効化
-Style/EmptyLineAfterGuardClause:
-  Enabled: true
 
 # 空メソッドの場合だけ1行で書かなければいけない理由が無い
 # 「セミコロンは使わない」に寄せた方がルールがシンプル

--- a/onkcop.gemspec
+++ b/onkcop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.53.0"
+  spec.add_dependency "rubocop", ">= 0.56.0"
   spec.add_dependency "rubocop-rspec", ">= 1.24.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
see: https://github.com/rubocop-hq/rubocop/pull/5886

```
Style/EmptyLineAfterGuardClause has the wrong namespace - should be Layout
```