### PR TITLE
Remove Style/EmptyLineAfterGuardClause config

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -249,10 +249,6 @@ Style/EmptyCaseCondition:
 Style/EmptyElse:
   EnforcedStyle: empty
 
-# ガード句と本質を分けるのは良いコードスタイルなので有効化
-Style/EmptyLineAfterGuardClause:
-  Enabled: true
-
 # 空メソッドの場合だけ1行で書かなければいけない理由が無い
 # 「セミコロンは使わない」に寄せた方がルールがシンプル
 Style/EmptyMethod:


### PR DESCRIPTION
In rubocop v0.56.0, Style/EmptyLineAfterGuardClause was moved to the Layout department.
In rubocop v0.59.0, Layout/EmptyLineAfterGuardClause is enabled by default.

I have not caught up to v0.59 yet, but I do not want to face warnings in current version.
So remove the configuration.