### PR TITLE
Fixed. invalid EnforcedStyle 'equality_operators_only' for Style/YodaCondition since rubocop 0.63.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -409,8 +409,9 @@ Style/WordArray:
 
 # 0 <= foo && foo < 5 のように数直線上に並べるのは
 # コードを読みやすくするテクニックなので equality_operators_only に。
-Style/YodaCondition:
-  EnforcedStyle: equality_operators_only
+# Style/YodaCondition:
+#   # TODO: rubocop 0.63.0以降はforbid_for_equality_operators_onlyなので依存を引き上げれば有効にできる
+#   EnforcedStyle: forbid_for_equality_operators_only
 
 # 条件式で arr.size > 0 が使われた時に
 #   if !arr.empty?


### PR DESCRIPTION
When use rubocop 0.63.0 and onkcop 0.53.0.2, rubocop is failed in onkcop config...

# Context
## Gemfile
```ruby
gem "onkcop", "0.53.0.2", require: false
gem "rubocop", "0.63.0", require: false
```

## Log
```bash
$ bundle exec rubocop
Error: invalid EnforcedStyle 'equality_operators_only' for Style/YodaCondition found in vendor/bundle/ruby/2.6.0/gems/onkcop-0.53.0.2/config/rubocop.yml
Valid choices are: forbid_for_all_comparison_operators, forbid_for_equality_operators_only, require_for_all_comparison_operators, require_for_equality_operators_only
```

# Why?
`equality_operators_only` is changed to `forbid_for_equality_operators_only` since rubocop 0.63.0.

c.f. https://github.com/rubocop-hq/rubocop/pull/6411
