### PR TITLE
Ignored `Layout/IndentationConsistency`

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -38,8 +38,9 @@ Layout/IndentHash:
   EnforcedStyle: consistent
 
 # private/protected は一段深くインデントする
-Layout/IndentationConsistency:
-  EnforcedStyle: rails
+# TODO: rubocop 0.72.0でEnforcedStyle名が変わったのでコメントアウト。0.72.0以降になれば有効にできる
+# Layout/IndentationConsistency:
+#   EnforcedStyle: indented_internal_methods
 
 # メソッドチェーン感がより感じられるインデントにする
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
# Context
I upgraded to rubocop v0.72.0, rubocop is failed in onkcop 

```ruby
# Gemfile
gem "onkcop", require: false, github: "sue445/onkcop", branch: "rubocop_0.68.0" # c.f. https://github.com/onk/onkcop/pull/62
gem "rubocop", "0.72.0", require: false
```

```
$ bundle exec rubocop -P
Error: obsolete `EnforcedStyle: rails` (for Layout/IndentationConsistency) found in vendor/bundle/ruby/2.6.0/bundler/gems/onkcop-6256494c1f86/config/rubocop.yml
`EnforcedStyle: rails` has been renamed to `EnforcedStyle: indented_internal_methods`
```

# Why?
`EnforcedStyle: rails` is renamed to `EnforcedStyle: indented_internal_methods` since rubocop v0.72.0

c.f. https://github.com/rubocop-hq/rubocop/pull/7163

So I ignored this.

# Postscript
https://github.com/onk/onkcop/pull/62 is not merged yet.
So please merge quickly if no problem 🙏 