### PR TITLE
rename `Layout/IndentArray`, `Layout/IndentHash` and `Layout/IndentationConsistency` for rubocop >= 0.72

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -29,17 +29,17 @@ Layout/ExtraSpacing:
 # special_inside_parentheses (default) と比べて
 # * 横に長くなりづらい
 # * メソッド名の長さが変わったときに diff が少ない
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 # ({ と hash を開始した場合に ( の位置にインデントさせる
 # そもそも {} が必要ない可能性が高いが Style/BracesAroundHashParameters はチェックしないことにしたので
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 # private/protected は一段深くインデントする
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # メソッドチェーン感がより感じられるインデントにする
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
cf. #62, #63 

rubocop is now >= 0.72
