### PR TITLE
Resolved rubocop 0.77.0 changes

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -149,7 +149,7 @@ Metrics/PerceivedComplexity:
 
 # has_ から始まるメソッドは許可する
 Naming/PredicateName:
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - "is_"
     - "have_"
   NamePrefix:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -160,7 +160,7 @@ Naming/PredicateName:
 # n(umber) といった 1 文字変数は頻出するし、前置詞(by, to, ...)や
 # よく知られた省略語 (op: operator とか pk: primary key とか) も妥当。
 # 変数 s にどんな文字列かを形容したい場合と、不要な場合とがある＝無効
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 #################### Performance ###########################


### PR DESCRIPTION
* The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName` since rubocop 0.77.0
  * c.f. https://github.com/rubocop-hq/rubocop/pull/7468
* `NamePrefixBlacklist` has been renamed to `ForbiddenPrefixes` since rubocop 0.77.0
  * c.f. https://github.com/rubocop-hq/rubocop/pull/7469
