### PR TITLE
The `Style/BracesAroundHashParameters` cop has been removed since rubocop 0.80.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -202,10 +202,6 @@ Style/BlockDelimiters:
   Exclude:
     - "spec/**/*_spec.rb"
 
-# option 等、明示的にハッシュにした方が分かりやすい場合もある
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # scope が違うとか親 module の存在確認が必要とかデメリットはあるが、
 # namespace 付きのクラスはかなり頻繁に作るので簡単に書きたい。
 Style/ClassAndModuleChildren:


### PR DESCRIPTION
c.f.

* https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0800-2020-02-18
* https://github.com/rubocop-hq/rubocop/issues/7641